### PR TITLE
Add multi party support and other stuff.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,13 +8,16 @@
   "sessionSecret": "",
   "discordInviteID": "",
   "discordBotToken": "",
-  "allianceID": null,
-  "corporationID": null,
+  "allianceIDs": [
+	null,
+	null
+  ],
+  "corporationIDs": [
+	null,
+	null
+  ]
   "guildID": "",
   "roleID": "",
   "listenIP": "127.0.0.1",
-  "listenPort": 5001,
-  "tickers": {
-    "4M-CORP": "4M"
-  }
+  "listenPort": 5001
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "license": "MIT",
   "dependencies": {
     "cookie-parser": "^1.4.3",
+    "eve-swagger": "^0.3.3",
     "express": "^4.15.2",
     "express-session": "^1.15.2",
     "moment": "^2.18.1",
-    "neow": "^1.0.0",
     "node-cron": "^1.1.3",
     "passport": "^0.3.2",
     "passport-discord": "^0.1.2",


### PR DESCRIPTION
I have modified this code because below reasons.

1. Change the public information query from XMPAPI to ESI.
2. Get ticker from ESI.
3. Support multi corporations and alliances.(So I have modified the logic in cron so that one jump from one auth corp to another auth corp will not lose membership).
4. Update nickname first, since no matter whether he/she is in auth group, this program will also invite he/she to the discord server, so I update their nickname first.
5. Change the return data from json to html, I have tested this program in a 3000 members' alliance, have got around 200 auth number in the first day and someone told me that in the last step he/she will download the json instead of redirect to. I have no idea what happened to their browser, so I just change the json to html.